### PR TITLE
Implement /displayhtml command to render BigQuery JSON as HTML table

### DIFF
--- a/src/app/components/chat/chat.component.html
+++ b/src/app/components/chat/chat.component.html
@@ -370,7 +370,9 @@
                       <div class="thought-chip">Thought</div>
                     }
                     <div>
-                      @if (message.text) {
+                      @if (message.isTable && message.htmlContent) {
+                        <div [innerHTML]="sanitizeHtml(message.htmlContent)"></div>
+                      } @else if (message.text) {
                         @if (message.isEditing) {
                           <div class="edit-message-container">
                             <textarea


### PR DESCRIPTION
This commit introduces a new chat command `/displayhtml`. When this command is entered, the application expects the next agent message to be a JSON string conforming to the BigQuery queryResponse schema.

If a valid JSON message is received while in this mode:
- It's parsed and transformed into an HTML table.
- The HTML table is then displayed in the chat interface.
- CSS styles are included for basic table formatting.

Modifications include:
- `chat.component.ts`: Added logic to handle the command, manage state (`expectingHtmlJson`), parse JSON, generate HTML using `generateTableHtml`, and sanitize it.
- `chat.component.html`: Updated to conditionally render HTML content using `[innerHTML]` when a message is flagged as a table.